### PR TITLE
[feat] 예외처리 및 공동응답처리

### DIFF
--- a/src/main/java/mju/nnews3/common/GlobalExcptionHandler.java
+++ b/src/main/java/mju/nnews3/common/GlobalExcptionHandler.java
@@ -2,7 +2,7 @@ package mju.nnews3.common;
 
 import jakarta.servlet.http.HttpServletRequest;
 import mju.nnews3.execption.BusinessException;
-import mju.nnews3.execption.fail.FailCode;
+import mju.nnews3.execption.error.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExcptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<Response<Void>> handleBusinessException(BusinessException ex, HttpServletRequest request) {
-        FailCode code = ex.getFailCode();
+        ErrorCode code = ex.getFailCode();
         return ResponseEntity
                 .status(code.getHttpStatus())
                 .body(Response.fail(code.getHttpStatus(), code.getMsg()));

--- a/src/main/java/mju/nnews3/common/GlobalExcptionHandler.java
+++ b/src/main/java/mju/nnews3/common/GlobalExcptionHandler.java
@@ -1,0 +1,40 @@
+package mju.nnews3.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import mju.nnews3.execption.BusinessException;
+import mju.nnews3.execption.fail.FailCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExcptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Response<Void>> handleBusinessException(BusinessException ex, HttpServletRequest request) {
+        FailCode code = ex.getFailCode();
+        return ResponseEntity
+                .status(code.getHttpStatus())
+                .body(Response.fail(code.getHttpStatus(), code.getMsg()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Response<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+        String errorMsg = ex.getBindingResult().getFieldError() != null
+                ? ex.getBindingResult().getFieldError().getDefaultMessage()
+                : "잘못된 요청입니다.";
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.fail(HttpStatus.BAD_REQUEST, errorMsg));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Response<Void>> handleUnexpectedException(Exception ex) {
+        ex.printStackTrace();
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Response.fail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류"));
+    }
+}

--- a/src/main/java/mju/nnews3/common/Response.java
+++ b/src/main/java/mju/nnews3/common/Response.java
@@ -1,0 +1,22 @@
+package mju.nnews3.common;
+
+import org.springframework.http.HttpStatus;
+
+public record Response<T>(
+        boolean success,
+        int status,
+        String msg,
+        T data
+) {
+    public static <T> Response<T> success(T data, String msg) {
+        return new Response<>(true, HttpStatus.OK.value(), msg, data);
+    }
+
+    public static <T> Response<T> success(T data) {
+        return success(data, "ok");
+    }
+
+    public static <T> Response<T> fail(HttpStatus status, String msg) {
+        return new Response<>(false, status.value(), msg, null);
+    }
+}

--- a/src/main/java/mju/nnews3/execption/BadRequestException.java
+++ b/src/main/java/mju/nnews3/execption/BadRequestException.java
@@ -1,0 +1,14 @@
+package mju.nnews3.execption;
+
+import mju.nnews3.execption.fail.FailCode;
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BusinessException {
+    public BadRequestException() {
+        super(FailCode.INVALID_INPUT);
+    }
+
+    public BadRequestException(String msg) {
+        super(FailCode.INVALID_INPUT);
+    }
+}

--- a/src/main/java/mju/nnews3/execption/BadRequestException.java
+++ b/src/main/java/mju/nnews3/execption/BadRequestException.java
@@ -1,14 +1,13 @@
 package mju.nnews3.execption;
 
-import mju.nnews3.execption.fail.FailCode;
-import org.springframework.http.HttpStatus;
+import mju.nnews3.execption.error.ErrorCode;
 
 public class BadRequestException extends BusinessException {
     public BadRequestException() {
-        super(FailCode.INVALID_INPUT);
+        super(ErrorCode.INVALID_INPUT);
     }
 
     public BadRequestException(String msg) {
-        super(FailCode.INVALID_INPUT);
+        super(ErrorCode.INVALID_INPUT);
     }
 }

--- a/src/main/java/mju/nnews3/execption/BusinessException.java
+++ b/src/main/java/mju/nnews3/execption/BusinessException.java
@@ -1,0 +1,16 @@
+package mju.nnews3.execption;
+
+import mju.nnews3.execption.fail.FailCode;
+
+public class BusinessException extends RuntimeException{
+    private final FailCode failCode;
+
+    public BusinessException(FailCode failCode) {
+        super(failCode.getMsg());
+        this.failCode = failCode;
+    }
+
+    public FailCode getFailCode() {
+        return failCode;
+    }
+}

--- a/src/main/java/mju/nnews3/execption/BusinessException.java
+++ b/src/main/java/mju/nnews3/execption/BusinessException.java
@@ -1,16 +1,16 @@
 package mju.nnews3.execption;
 
-import mju.nnews3.execption.fail.FailCode;
+import mju.nnews3.execption.error.ErrorCode;
 
 public class BusinessException extends RuntimeException{
-    private final FailCode failCode;
+    private final ErrorCode errorCode;
 
-    public BusinessException(FailCode failCode) {
-        super(failCode.getMsg());
-        this.failCode = failCode;
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
     }
 
-    public FailCode getFailCode() {
-        return failCode;
+    public ErrorCode getFailCode() {
+        return errorCode;
     }
 }

--- a/src/main/java/mju/nnews3/execption/NotFoundException.java
+++ b/src/main/java/mju/nnews3/execption/NotFoundException.java
@@ -1,0 +1,14 @@
+package mju.nnews3.execption;
+
+import mju.nnews3.execption.fail.FailCode;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException() {
+        super(FailCode.NOT_FOUND);
+    }
+
+    public NotFoundException(String msg) {
+        super(FailCode.NOT_FOUND);
+    }
+}

--- a/src/main/java/mju/nnews3/execption/NotFoundException.java
+++ b/src/main/java/mju/nnews3/execption/NotFoundException.java
@@ -1,14 +1,13 @@
 package mju.nnews3.execption;
 
-import mju.nnews3.execption.fail.FailCode;
-import org.springframework.http.HttpStatus;
+import mju.nnews3.execption.error.ErrorCode;
 
 public class NotFoundException extends BusinessException {
     public NotFoundException() {
-        super(FailCode.NOT_FOUND);
+        super(ErrorCode.NOT_FOUND);
     }
 
     public NotFoundException(String msg) {
-        super(FailCode.NOT_FOUND);
+        super(ErrorCode.NOT_FOUND);
     }
 }

--- a/src/main/java/mju/nnews3/execption/error/ErrorCode.java
+++ b/src/main/java/mju/nnews3/execption/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package mju.nnews3.execption.fail;
+package mju.nnews3.execption.error;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum FailCode {
+public enum ErrorCode {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다.");

--- a/src/main/java/mju/nnews3/execption/fail/FailCode.java
+++ b/src/main/java/mju/nnews3/execption/fail/FailCode.java
@@ -1,0 +1,16 @@
+package mju.nnews3.execption.fail;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FailCode {
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String msg;
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #1 

## Key Changes 🔑
- API 응답을 Response<T>로 통일
- 예외 발생 시 HTTP 상태 코드에 맞는 응답과 함께 메시지를 제공하도록 처리
- 비지니스 예외와 시스템 예외를 구분

| 클래스 | 역할 |
|--------|------|
| `Response<T>` | 성공/실패를 통일된 구조로 포장하는 record |
| `BusinessException` | 모든 커스텀 예외의 상위 클래스 |
| `FailCode` | 응답 상태와 메시지를 묶은 enum |
| `GlobalExceptionHandler` | 예외를 잡고 `Response.fail`로 매핑 |
| `NotFoundException` | 상황에 따라 발생시키는 구체적인 예외 |
| `BadRequestException` | 상황에 따라 발생시키는 구체적인 예외 |


## To Reviewers 📢
-
