### PR TITLE
[feat] 사용자 관련 뉴스 정보 업데이트

### DIFF
--- a/src/main/java/mju/nnews3/api/controller/MemberLikeController.java
+++ b/src/main/java/mju/nnews3/api/controller/MemberLikeController.java
@@ -4,6 +4,7 @@ import mju.nnews3.api.dto.req.LikeReq;
 import mju.nnews3.common.Response;
 import mju.nnews3.service.MemberLikeService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,4 +26,12 @@ public class MemberLikeController {
         return ResponseEntity.ok(Response.success(null));
     }
 
+    @DeleteMapping("/user/v1/news/like")
+    public ResponseEntity<Response<Void>> deleteLike(
+            @RequestBody LikeReq likeReq
+    ) {
+        memberLikeService.deleteLike(likeReq);
+
+        return ResponseEntity.ok(Response.success(null));
+    }
 }

--- a/src/main/java/mju/nnews3/api/controller/MemberLikeController.java
+++ b/src/main/java/mju/nnews3/api/controller/MemberLikeController.java
@@ -1,0 +1,28 @@
+package mju.nnews3.api.controller;
+
+import mju.nnews3.api.dto.req.LikeReq;
+import mju.nnews3.common.Response;
+import mju.nnews3.service.MemberLikeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberLikeController {
+    private final MemberLikeService memberLikeService;
+
+    public MemberLikeController(MemberLikeService memberLikeService) {
+        this.memberLikeService = memberLikeService;
+    }
+
+    @PostMapping("/user/v1/news/like")
+    public ResponseEntity<Response<Void>> updateLike(
+            @RequestBody LikeReq likeReq
+    ) {
+        memberLikeService.updateLike(likeReq);
+
+        return ResponseEntity.ok(Response.success(null));
+    }
+
+}

--- a/src/main/java/mju/nnews3/api/controller/ViewController.java
+++ b/src/main/java/mju/nnews3/api/controller/ViewController.java
@@ -1,0 +1,27 @@
+package mju.nnews3.api.controller;
+
+import mju.nnews3.api.dto.req.ViewReq;
+import mju.nnews3.common.Response;
+import mju.nnews3.service.ViewService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ViewController {
+    private final ViewService viewService;
+
+    public ViewController(ViewService viewService) {
+        this.viewService = viewService;
+    }
+
+    @PostMapping("/user/v1/news/view")
+    public ResponseEntity<Response<Void>> updateView(
+            @RequestBody ViewReq viewReq
+    ) {
+        viewService.updateView(viewReq);
+
+        return ResponseEntity.ok(Response.success(null));
+    }
+}

--- a/src/main/java/mju/nnews3/api/dto/req/LikeReq.java
+++ b/src/main/java/mju/nnews3/api/dto/req/LikeReq.java
@@ -1,0 +1,7 @@
+package mju.nnews3.api.dto.req;
+
+public record LikeReq(
+        Long userId,
+        Long newsId
+) {
+}

--- a/src/main/java/mju/nnews3/api/dto/req/ViewReq.java
+++ b/src/main/java/mju/nnews3/api/dto/req/ViewReq.java
@@ -1,0 +1,7 @@
+package mju.nnews3.api.dto.req;
+
+public record ViewReq(
+       Long userId,
+       Long newsId
+) {
+}

--- a/src/main/java/mju/nnews3/domain/Member.java
+++ b/src/main/java/mju/nnews3/domain/Member.java
@@ -60,7 +60,12 @@ public class Member {
             updated.add(newKeyword);
         }
 
-        // List를 다시 String으로 변환하여 저장
         this.keyword = updated.stream().collect(Collectors.joining(","));
     }
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<View> views = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberLike> likes = new ArrayList<>();
 }

--- a/src/main/java/mju/nnews3/domain/MemberLike.java
+++ b/src/main/java/mju/nnews3/domain/MemberLike.java
@@ -1,0 +1,25 @@
+package mju.nnews3.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_like")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/mju/nnews3/domain/News.java
+++ b/src/main/java/mju/nnews3/domain/News.java
@@ -8,7 +8,9 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Entity
 @Table(name = "news")
@@ -45,4 +47,15 @@ public class News {
 
     @Column(name = "view")
     private Long view;
+
+    @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<View> views = new ArrayList<>();
+
+    public void updateView() {
+        if (this.view == null) {
+            this.view = 0L;
+        } else {
+            this.view += 1;
+        }
+    }
 }

--- a/src/main/java/mju/nnews3/domain/View.java
+++ b/src/main/java/mju/nnews3/domain/View.java
@@ -1,0 +1,25 @@
+package mju.nnews3.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "view")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class View {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/mju/nnews3/domain/repository/MemberLikeRepository.java
+++ b/src/main/java/mju/nnews3/domain/repository/MemberLikeRepository.java
@@ -1,0 +1,13 @@
+package mju.nnews3.domain.repository;
+
+import mju.nnews3.domain.MemberLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import mju.nnews3.domain.Member;
+import mju.nnews3.domain.News;
+
+@Repository
+public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
+    MemberLike findByMemberAndNews(Member member, News news);
+}

--- a/src/main/java/mju/nnews3/domain/repository/ViewRepository.java
+++ b/src/main/java/mju/nnews3/domain/repository/ViewRepository.java
@@ -1,0 +1,13 @@
+package mju.nnews3.domain.repository;
+
+import mju.nnews3.domain.Member;
+import mju.nnews3.domain.News;
+import mju.nnews3.domain.View;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ViewRepository extends JpaRepository<View, Long> {
+    View findByMemberAndNews(Member member, News news);
+
+}

--- a/src/main/java/mju/nnews3/service/MemberLikeService.java
+++ b/src/main/java/mju/nnews3/service/MemberLikeService.java
@@ -41,4 +41,19 @@ public class MemberLikeService {
         }
     }
 
+    @Transactional
+    public void deleteLike(LikeReq likeReq) {
+        Member member = memberRepository.findById(likeReq.userId())
+                .orElseThrow(() -> new NotFoundUserException());
+        News news = newsRepository.findById(likeReq.newsId())
+                .orElseThrow(() -> new NotFoundNewsException());
+
+        MemberLike existingLike = memberLikeRepository.findByMemberAndNews(member, news);
+
+        if (existingLike == null) {
+            throw new NotFoundNewsException();
+        }
+
+        memberLikeRepository.delete(existingLike);
+    }
 }

--- a/src/main/java/mju/nnews3/service/MemberLikeService.java
+++ b/src/main/java/mju/nnews3/service/MemberLikeService.java
@@ -1,0 +1,44 @@
+package mju.nnews3.service;
+
+import mju.nnews3.api.dto.req.LikeReq;
+import mju.nnews3.domain.Member;
+import mju.nnews3.domain.MemberLike;
+import mju.nnews3.domain.News;
+import mju.nnews3.domain.repository.MemberLikeRepository;
+import mju.nnews3.domain.repository.MemberRepository;
+import mju.nnews3.domain.repository.NewsRepository;
+import mju.nnews3.execption.NotFoundNewsException;
+import mju.nnews3.execption.NotFoundUserException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberLikeService {
+    private final MemberRepository memberRepository;
+    private final MemberLikeRepository memberLikeRepository;
+    private final NewsRepository newsRepository;
+
+    public MemberLikeService(MemberRepository memberRepository, MemberLikeRepository memberLikeRepository, NewsRepository newsRepository) {
+        this.memberRepository = memberRepository;
+        this.memberLikeRepository = memberLikeRepository;
+        this.newsRepository = newsRepository;
+    }
+
+    @Transactional
+    public void updateLike(LikeReq likeReq) {
+        Member member = memberRepository.findById(likeReq.userId())
+                .orElseThrow(() -> new NotFoundUserException());
+        News news = newsRepository.findById(likeReq.newsId())
+                .orElseThrow(() -> new NotFoundNewsException());
+
+        MemberLike existingLike = memberLikeRepository.findByMemberAndNews(member, news);
+
+        if (existingLike != null) {
+            return;
+        } else {
+            MemberLike newLike = new MemberLike(null, news, member);
+            memberLikeRepository.save(newLike);
+        }
+    }
+
+}

--- a/src/main/java/mju/nnews3/service/MemberService.java
+++ b/src/main/java/mju/nnews3/service/MemberService.java
@@ -9,6 +9,7 @@ import mju.nnews3.execption.NotFoundUserException;
 import mju.nnews3.domain.repository.MemberRepository;
 import mju.nnews3.execption.error.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -39,6 +40,7 @@ public class MemberService {
         return new MainInfoRes(member.getNickname(), today, weather);
     }
 
+    @Transactional
     public void updateKeyword(KeywordReq keywordReq) {
         if (keywordReq.newKeyword() != null) {
             String newKeyword = keywordReq.newKeyword();

--- a/src/main/java/mju/nnews3/service/ViewService.java
+++ b/src/main/java/mju/nnews3/service/ViewService.java
@@ -1,0 +1,48 @@
+package mju.nnews3.service;
+
+import mju.nnews3.api.dto.req.ViewReq;
+import mju.nnews3.domain.Member;
+import mju.nnews3.domain.News;
+import mju.nnews3.domain.View;
+import mju.nnews3.domain.repository.MemberRepository;
+import mju.nnews3.domain.repository.NewsRepository;
+import mju.nnews3.domain.repository.ViewRepository;
+import mju.nnews3.execption.NotFoundNewsException;
+import mju.nnews3.execption.NotFoundUserException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ViewService {
+    private final ViewRepository viewRepository;
+    private final NewsRepository newsRepository;
+    private final MemberRepository memberRepository;
+
+    public ViewService(ViewRepository viewRepository, NewsRepository newsRepository, MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+        this.viewRepository = viewRepository;
+        this.newsRepository = newsRepository;
+    }
+
+    @Transactional
+    public void updateView(ViewReq viewReq) {
+        Member member = memberRepository.findById(viewReq.userId())
+                .orElseThrow(() -> new NotFoundUserException());
+
+        News news = newsRepository.findById(viewReq.newsId())
+                .orElseThrow(() -> new NotFoundNewsException());
+
+        View existingView = viewRepository.findByMemberAndNews(member, news);
+
+        if (existingView != null) {
+            return;
+        } else {
+            View view = new View(null, news, member);
+            viewRepository.save(view);
+
+            news.updateView();
+
+            newsRepository.save(news);
+        }
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #25 

## Key Changes 🔑
- 사용자가 좋아하는 뉴스와 본 뉴스 정보를 업데이트합니다.
- 사용자가 본 뉴스는 news테이블의 view를 추가적으로 증가시켜줍니다.
- 사용자가 좋아하는 뉴스를 취수한 경우 해당 내용을 DB에서 삭제합니다.

## To Reviewers 📢
-